### PR TITLE
Option for retweet of retweet

### DIFF
--- a/aws_lambda_tweet_bot/service/conditional_rt.py
+++ b/aws_lambda_tweet_bot/service/conditional_rt.py
@@ -82,6 +82,13 @@ def bot_handler(env, conf):
                 # reply tweet must not be retweeted
                 if status.text.startswith('@'):
                     matches = False
+                # retweet of retweet (default is 'not allowed')
+                if not condition.get('rt_of_rt', False) and \
+                        hasattr(status, 'retweeted_status'):
+                    logger.info("Following tweet is not made by original "
+                                "author so not retweeted:\n%s",
+                                status.text.encode('utf_8'))
+                    matches = False
                 if matches:
                     # Even if condition matches, tweets are filtered by
                     # blacklist keywords

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import setuptools
 
 
 setuptools.setup(name='aws_lambda_tweet_bot',
-                 version='1.1.0',
+                 version='1.2.0',
                  author='edechaninfo',
                  author_email='edechaninfo@gmail.com',
                  packages=setuptools.find_packages(),

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -110,6 +110,10 @@ class FakeStatus(object):
     def extended_entities(self):
         return self.status['extended_entities']
 
+    @property
+    def retweeted_status(self):
+        return FakeStatus(self.status['retweeted_status'])
+
 
 class FakeTweepyApi(object):
     def __init__(self, statuses={}, update_error=False):

--- a/test/service/sample_data.py
+++ b/test/service/sample_data.py
@@ -23,6 +23,14 @@ sample_user_statuses = [
         "text": "Ede-chan is promising voice actor"
     },
     {
+        "id": 789031958014135025,
+        "text": "RT @seiyu1: I will take a role of new character.",
+        "retweeted_status": {
+            "id": 769030958014135025,
+            "text": "I will take a role of new character"
+        }
+    },
+    {
         "id": 789029558014135025,
         "text": "Recording will start soon :)",
         "extended_entities": {
@@ -38,6 +46,14 @@ sample_user_statuses = [
                     'type': 'photo'
                 }
             ]
+        }
+    },
+    {
+        "id": 789027958014135025,
+        "text": "RT @animeseiyu: Ede-chan will be on the stage!",
+        "retweeted_status": {
+            "id": 769027958014135025,
+            "text": "Ede-chan will be on the stage!"
         }
     },
     {

--- a/test/service/test_conditional_rt.py
+++ b/test/service/test_conditional_rt.py
@@ -76,7 +76,7 @@ class TestConditionalRT(unittest.TestCase):
         self.assertIn(789065945014135025, mock_tweepy._retweet_ids)
         self.assertIn(789058945014135025, mock_tweepy._retweet_ids)
 
-    def test_user_timeline_with_photo(self):
+    def test_user_timeline_incl_reply(self):
         tweet_watches = [
             dict(id=5, type='user', account='acc', match_strings=['Ede-chan'])
         ]
@@ -91,7 +91,7 @@ class TestConditionalRT(unittest.TestCase):
         self.assertIn(889035945014145025, mock_tweepy._retweet_ids)
         self.assertIn(889025945014135025, mock_tweepy._retweet_ids)
 
-    def test_user_timeline_incl_reply(self):
+    def test_user_timeline_with_photo(self):
         tweet_watches = [
             dict(id=5, type='user', account='acc', match_strings=['Ede-chan'],
                  photo=True)
@@ -105,6 +105,22 @@ class TestConditionalRT(unittest.TestCase):
         self.assertEqual(789035945014145025, env['since_id'])
         self.assertIn(789035945014145025, mock_tweepy._retweet_ids)
         self.assertIn(789029558014135025, mock_tweepy._retweet_ids)
+        self.assertIn(789025945014135025, mock_tweepy._retweet_ids)
+
+    def test_user_timeline_enable_rt_of_rt(self):
+        tweet_watches = [
+            dict(id=5, type='user', account='acc', match_strings=['Ede-chan'],
+                 rt_of_rt=True)
+        ]
+        mock_dynamodb = FakeDynamodbTable(tweet_watches)
+        mock_tweepy = FakeTweepyApi(dict(user=dict(acc=sample_user_statuses)))
+        env = dict(twitter_env='test', since_id=709025945014135025)
+
+        self._bot_handler(env, self.config, mock_tweepy, mock_dynamodb)
+        self.assertEqual(3, len(mock_tweepy._retweet_ids))
+        self.assertEqual(789035945014145025, env['since_id'])
+        self.assertIn(789035945014145025, mock_tweepy._retweet_ids)
+        self.assertIn(789027958014135025, mock_tweepy._retweet_ids)
         self.assertIn(789025945014135025, mock_tweepy._retweet_ids)
 
     def test_list_timeline_with_blacklist(self):


### PR DESCRIPTION
Some user might retweet kind of unofficial account tweets. In many
cases, we do not want to retweet a status made by unintended users.
Therefore, default behavior is suppressing retweet of retweet. If
operator want to retweet some retweeted statuses, 'rt_of_rt' must be set
as True.

Resolves #14