### PR TITLE
CI with real services

### DIFF
--- a/aws_lambda_tweet_bot/service/ameba_now_watch.py
+++ b/aws_lambda_tweet_bot/service/ameba_now_watch.py
@@ -29,7 +29,7 @@ logger.setLevel(logging.INFO)
 
 
 AMEBA_NOW_HOST = 'http://now.ameba.jp'
-TEXT_DEFAULT_MAX = 80
+TEXT_DEFAULT_MAX = 70
 
 
 # Ameba Now CDATA parser. parsed_data conatins

--- a/aws_lambda_tweet_bot/service/blog_watch.py
+++ b/aws_lambda_tweet_bot/service/blog_watch.py
@@ -144,7 +144,7 @@ def bot_handler(env, conf):
                     try:
                         twbody = blog_item['body_format'].format(**entry)
                     except KeyError as e:
-                        errKey = str(e)[1:-1]
+                        errKey = e.message.encode('utf_8')
                         raise Exception("{%s} is not available in blog "
                                         "entry. Please check body_format." %
                                         errKey)

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,12 @@
+machine:
+  services:
+  - docker
+
+dependencies:
+  override:
+  - docker pull peopleperhour/dynamodb
+
+test:
+  override:
+  - docker run -d --name dynamodb -p 8000:8000 peopleperhour/dynamodb
+  - python ./setup.py test

--- a/test/credentials_local.conf
+++ b/test/credentials_local.conf
@@ -1,0 +1,8 @@
+[default]
+tenant_id = test
+
+[aws]
+aws_access_key_id = anything
+aws_secret_access_key = anything
+region_name = us-west-2
+endpoint_url = http://localhost:8000

--- a/test/service/base.py
+++ b/test/service/base.py
@@ -1,0 +1,75 @@
+# Copyright 2016 edechaninfo
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+
+import boto3
+
+from aws_lambda_tweet_bot.utils import get_dynamodb_table
+from config import Config
+
+from test import FakeLogger
+
+
+class BaseTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        basepath = os.path.dirname(os.path.abspath(__file__))
+        filepath = os.path.normpath(
+            os.path.join(basepath, '../credentials_local.conf'))
+        cls.config = Config(filepath)
+        cls.dynamo = boto3.client('dynamodb', **cls.config.aws_config)
+        resp = cls.dynamo.list_tables()
+        for table_name in resp.get('TableNames', []):
+            cls.dynamo.delete_table(TableName=table_name)
+
+    def setUp(self):
+        self.logger = FakeLogger()
+        self.dynamo.create_table(
+            AttributeDefinitions=[
+                {
+                    'AttributeName': 'service_id',
+                    'AttributeType': 'S'
+                },
+            ],
+            TableName='test_env',
+            KeySchema=[
+                {
+                    'AttributeName': 'service_id',
+                    'KeyType': 'HASH'
+                },
+            ],
+            ProvisionedThroughput={
+                'ReadCapacityUnits': 1,
+                'WriteCapacityUnits': 1
+            },
+        )
+
+    def tearDown(self):
+        self.dynamo.delete_table(TableName='test_env')
+
+    def add_items_to_local_dynamodb(self, table_name, items):
+        table = get_dynamodb_table(table_name, self.config)
+        for item in items:
+            table.put_item(Item=item)
+
+    def get_env_from_local_dynamodb(self, service_id):
+        table = get_dynamodb_table('env', self.config)
+        resp = table.get_item(Key={'service_id': service_id})
+        return resp['Item']
+
+    def set_env_to_local_dynamodb(self, service_id, item):
+        item['service_id'] = service_id
+        self.add_items_to_local_dynamodb('env', [item])


### PR DESCRIPTION
Sometimes, unit tests with mock services failed are not complete because
it is almost impossible to create perfect mock. This BOT relies on
Twitter and DynamoDB, therefore I want to use those real services for CI
process.

DynamoDB has an official binary which can be run locally. By using
Docker image, we can test real inputs/outputs for DynamoDB in the local
env.

Twitter does not have a local binary. Moreover, timeline results will
change in the real environment so mock feature is still convenient for
unit tests. However, posting tweets should be tested in the real
environment at least before production deployment, because that part is
most error-prone part.

Real twitter test is enabled by setting environment variable
TW_TEST_ENABLED=true. Credential info for Twitter can be defined by
environment configs with TW_{TYPE}_{KEY} (e.g., TW_TEST_CONSUMER_KEY).
By defining these variables in Circle CI or other CI system, you can run
unit tests with real Twitter server in CI.